### PR TITLE
fixed destroy notification when app killed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,10 @@
 
   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.ingageco.capacitormusiccontrols.capacitormusiccontrolsplugin">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <application>
+      <service android:name="com.ingageco.capacitormusiccontrols.CMCNotifyKiller" />
+    </application>
   </manifest>
   

--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/CMCNotifyKiller.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/CMCNotifyKiller.java
@@ -2,7 +2,9 @@ package com.ingageco.capacitormusiccontrols;
 
 import java.lang.ref.WeakReference;
 
+import android.app.Activity;
 import android.app.Service;
+import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.os.Binder;
 import android.os.PowerManager;
@@ -27,6 +29,25 @@ public class CMCNotifyKiller extends Service {
 
 	private boolean foregroundStarted = false;
 
+
+	private Activity activity;
+	private ServiceConnection connection;
+	private boolean bounded;
+
+	public CMCNotifyKiller setActivity(Activity activity) {
+		this.activity = activity;
+		return this;
+	}
+
+	public CMCNotifyKiller setConnection(ServiceConnection connection) {
+		this.connection = connection;
+		return this;
+	}
+
+	public CMCNotifyKiller setBounded(boolean bounded) {
+		this.bounded = bounded;
+		return this;
+	}
 
 	@Override
 	public IBinder onBind(Intent intent) {
@@ -130,5 +151,14 @@ public class CMCNotifyKiller extends Service {
 	public void onDestroy() {
 		super.onDestroy();
 		sleepWell(true);
+	}
+
+	@Override
+	public void onTaskRemoved(Intent rootIntent) {
+		super.onTaskRemoved(rootIntent);
+		sleepWell(true);
+		if(bounded) {
+			activity.unbindService(connection);
+		}
 	}
 }

--- a/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
+++ b/android/src/main/java/com/ingageco/capacitormusiccontrols/CapacitorMusicControls.java
@@ -160,6 +160,8 @@ public class CapacitorMusicControls extends Plugin {
 			public void onServiceConnected(ComponentName className, IBinder binder) {
 				Log.i(TAG, "onServiceConnected");
 				final CMCNotifyKiller service = (CMCNotifyKiller) ((KillBinder) binder).service;
+
+				service.setActivity(activity).setConnection(this).setBounded(true);
 				my_notification.setKillerService(service);
 				service.startService(new Intent(activity, CMCNotifyKiller.class));
 				Log.i(TAG, "service Started");


### PR DESCRIPTION
Fixed issue#11: **Notification should be destroy if app is killed** 

- Added permission for foreground services.
- Referenced CMCNotifyKiller service inside application.
- Added onTaskRemoved inside CMCNotidyKiller to destroy notification when app is force closed by user.
- Added setter methods to be used when unbinding CMCNotidyKiller service .